### PR TITLE
rmp-serde upgraded due to found vulnerability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ deepsize = { version = "0.2.0", optional = true }
 env_logger = { version = "0.9.0", optional = true}
 log = "0.4.8"
 rayon = "1.5.0"
-rmp-serde = "0.15.0"
+rmp-serde = "1.1.1"
 serde = { version = "1.0.120", features = ["derive"] }
 tempfile = "3.2.0"
 


### PR DESCRIPTION
rmp-serde upgraded due to found vulnerability. See https://github.com/dapper91/ext-sort-rs/issues/11.