### PR TITLE
Dev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ext-sort"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "Unlicense"
 description = "rust external sort algorithm implementation"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ deepsize = { version = "0.2.0", optional = true }
 env_logger = { version = "0.9.0", optional = true}
 log = "0.4.8"
 rayon = "1.5.0"
-rmp-serde = "0.15.0"
+rmp-serde = "1.1.1"
 serde = { version = "1.0.120", features = ["derive"] }
 tempfile = "3.2.0"
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Activate `memory-limit` feature of the ext-sort crate on Cargo.toml:
 
 ```toml
 [dependencies]
-ext-sort = { version = "^0.1.3", features = ["memory-limit"] }
+ext-sort = { version = "^0.1.4", features = ["memory-limit"] }
 ```
 
 ```rust


### PR DESCRIPTION
- rmp-serde upgraded due to found vulnerability. See https://github.com/dapper91/ext-sort-rs/issues/11.